### PR TITLE
Grammar edits datacubes

### DIFF
--- a/dc_regularize.qmd
+++ b/dc_regularize.qmd
@@ -4,7 +4,7 @@
 
 ```{r}
 #| echo: false
-reticulate::use_python("C:/Users/alexc/AppData/Local/Microsoft/WindowsApps/python.exe")
+reticulate::use_python("/Users/gilbertocamara/.pyenv/versions/pysits/bin/python")
 ```
 
 :::{.panel-tabset}

--- a/dc_regularize.qmd
+++ b/dc_regularize.qmd
@@ -4,7 +4,7 @@
 
 ```{r}
 #| echo: false
-reticulate::use_python("/Users/gilbertocamara/.pyenv/versions/pysits/bin/python")
+reticulate::use_python("C:/Users/alexc/AppData/Local/Microsoft/WindowsApps/python.exe")
 ```
 
 :::{.panel-tabset}
@@ -41,19 +41,17 @@ Path(tempdir_py).mkdir(parents=True, exist_ok=True)
 
 ## The need for regular EO data cubes
 
-ARD collections available in AWS, MPC, USGS, and DEAFRICA are not regular in space and time. Bands may have different resolutions, images may not cover the entire tile, and time intervals are irregular. Clouds and sensor artifacts introduce “holes” in the data, which need to be filled to obtain a consistent time series. Most ML/DL libraries expect tensors of identical shape (n_samples × n_features × time). If time steps differ or values are missing, batch training breaks and the model learns spurious correlations. Regular cubes guarantee fixed-length feature vectors & GPU-friendly batches. Regularization turns heterogeneous image archives into a clean data structure that machine learning models can ingest directly. 
+Analysis Ready Data (ARD) collections are often irregular in space and time. Bands may have different resolutions, images may not cover entire tiles, and time intervals are inconsistent. Clouds and sensor artifacts introduce “holes” in the data, corrupting the time series. If time steps differ or values are missing, batch training breaks and the model learns spurious correlations. Additionally, most machine learning and deep learning libraries expect tensors of identical shape (n_samples × n_features × time). Regular data cubes guarantee fixed-length feature vectors and GPU-friendly batches. Regularization turns heterogeneous image archives into clean, structured data ready for machine learning models.
 
-Data from ARD collections can be converted into regular data cubes by calling `sits_regularize()`, which uses the  `gdalcubes` package [@Appel2019]. The `sits_regularize()` function has two components:
+Data from ARD collections can be converted into regular data cubes with `sits_regularize()`, which uses the `gdalcubes` package [@Appel2019]. This function has two components:
 
-1. Spatial harmonization: re-project and resample everything onto the same tiling system and same spatial resolution. For example, when Sentinel-1 and Sentinel-2 images are merged in `sits`, they are projected to tiles of the MGRS grid. 
+1. Spatial harmonization: reproject and resample everything onto the same tiling system and spatial resolution. For example, when Sentinel-1 and Sentinel-2 images are merged in `sits`, they are projected onto MGRS grid tiles.
 
-2. Temporal harmonization: creates equispaced intervals (e.g., 16-day, monthly or seasonal composites) and fills gaps due to cloud cover and sensor errors. In `sits`, all images inside a chosen interval are combined by stacking. Images are ordered by decreasing percentage of cloud cover. The least-cloud filled image is taken as reference, and the other images are used to try to fill its gaps. Pixels with persistent cloud-cover are marked as `NA` and are estimated during computation by temporal interpolation. 
-
-
+2. Temporal harmonization: creates equispaced intervals (e.g., 16-day, monthly, or seasonal composites), filling gaps introduced by cloud cover and sensor errors. `sits` stacks every image within a chosen interval to combine them. It sorts images in increasing order of cloud cover percentage. The least cloud-filled image is taken as a reference, and the others are used to try to fill its gaps. Pixels with persistent cloud cover are marked as `NA` and are temporally interpolated during computation.
 
 ## Regularizing Sentinel-2 images{-}
 
-In the following example, the user has created a non-regular data cube from the Sentinel-2 collection available in Microsoft's Planetary Computer (MPC) for tiles `20LKP` and `20LLP` in the state of Rondonia, Brazil. We first retrieve a non-regular ARD collection using `sits_cube()`.
+In the following example, we create a non-regular data cube from the Sentinel-2 collection available in Microsoft's Planetary Computer (MPC). The area lies within the state of Rondônia, Brazil, and is defined by the MGRS tiles `20LKP` and `20LLP`. We use `sits_cube()` to retrieve the collection.
 
 :::{.panel-tabset}
 ## R
@@ -120,10 +118,14 @@ plot(s2_cube_rondonia)
 knitr::include_graphics("./images/dc_regularize_s2_20llp_non_reg.png") 
 ```
 
-Because of the different acquisition orbits of the Sentinel-2A and Sentinel-2B satellites, the two tiles also have different timelines. Tile `20LKP` has 12 instances, while tile `20LLP` has 24 instances for the chosen period. The function `sits_regularize()` builds a data cube with a regular timeline and a best estimate of a valid pixel for each interval. The `period` parameter sets the time interval between two images. Values of `period` use the ISO8601 time period specification, which defines time intervals as `P[n]Y[n]M[n]D`, where "Y" stands for years, "M" for months, and "D" for days. Thus, `P1M` stands for a one-month period, `P15D` for a fifteen-day period. When joining different images to get the best image for a period, `sits_regularize()` uses an aggregation method that organizes the images for the chosen interval in order of increasing cloud cover and then selects the first cloud-free pixel. In the example, we use a spatial resolution of 40-meter for the regular cube to speed up processing; in actual case, we suggest using a 10-meter spatial resolution for the cube.
 
-Before regularizing the cube, we suggest copying the ARD data to a local directory to speed up processing. The original data will be temporally stored locally. In this way, the actual work of producing a regular data cube will be split into two parts: (a) downloading data from ARD collections; (b) building a data cube from local files. After the regular data cube has been built, the ARD imagens can be deleted. Depending on the speed of your connection, the `sits_cube_copy()` may take some time.
+Different satellites—even those within the same mission, such as Sentinel-2A and Sentinel-2B—follow slightly different orbits and acquire data at different times. These are referred to as different *acquisition orbits*. Due to factors such as the Earth's rotation and the lack of perfect alignment between Earth's orbit and the satellites’ paths, some regions are not observed by both satellites during each orbital cycle. As a result, image acquisition timelines can differ between tiles.
 
+In our example, tile `20LKP` has twelve images within the selected time period, while tile `20LLP` has twenty-four. To harmonize these differences, we use the `sits_regularize()` function, which builds a data cube with a regular timeline and estimates the best available pixel value for each time interval.
+
+Let’s now examine some technical aspects of `sits_regularize()`. The period parameter defines the time interval between observations, using the ISO 8601 time period format. This format specifies intervals as `P[n]Y[n]M[n]D`, where "Y" stands for years, "M" for months, and "D" for days. For example, `P1M` denotes a one-month interval, and `P15D` denotes a fifteen-day interval. For each time step, `sits_regularize()` identifies all available images within the defined window. Then, for each pixel, it sorts these candidate values by increasing cloud cover and selects the first cloud-free value. In this way, the function builds a regular time series for each pixel, even when observations come from different dates or satellites.
+
+In this example, we set the regular cube’s spatial resolution to forty meters to speed up processing. For real-world applications, however, we recommend using a resolution of ten meters. We also recommend copying the ARD data to a local directory using `sits_cube_copy()` before applying regularization. This separates the process of creating a regular data cube into two distinct steps: (a) downloading data from ARD collections and (b) building the data cube from local files. This approach can significantly speed up processing. After sits builds the regular cube, the ARD images can be deleted to save space. Finally, keep in mind that depending on the speed of your Internet connection, `sits_cube_copy()` may take some time to complete.
 
 
 :::{.panel-tabset}
@@ -172,7 +174,33 @@ knitr::include_graphics("./images/dc_regularize_20llp_reg.png")
 
 ## Regularizing Sentinel-1 images{-}
 
-Because of their acquisition mode, SAR images are usually stored following their geometry of acquisition, which is inclined with respect to the Earth. This is the case of GRD and RTC collections available in Microsoft Planetary Computer (MPC). To allow easier use of Sentinel-1 data and to merge them with Sentinel-2 images, regularization in sits reprojects SAR data to the MGRS grid, as shown in the following example. The example uses the "SENTINEL-1-RTC" collection from MPC. 
+We have already discussed how different acquisition orbits can result in mismatched timelines. But that is not the only irregularity we need to address. Different satellites may also have different *acquisition modes*—that is, the way their sensors capture data, including direction, resolution, swath width, and polarization.
+
+In the case of SAR (Synthetic Aperture Radar) satellites like Sentinel-1, the acquisition mode determines:
+
+- Viewing geometry (how the radar observes the ground),
+
+- Incidence angle (the angle between the radar beam and the vertical to the Earth),
+
+- Spatial resolution and coverage area,
+
+- Whether it collects single or dual polarization (e.g., VV, VH).
+
+But why is this relevant?
+
+SAR images are usually captured at an oblique angle (not straight down), resulting in a slanted geometry known as *slant range*, rather than a map-like view called *ground range*. As a result, raw SAR images do not align well with optical imagery like Sentinel-2, which uses a nadir (straight-down) viewing geometry.
+
+To facilitate the integration of Sentinel-1 and Sentinel-2 data, `sits_regularize()` reprojects SAR images to the MGRS grid. Internally, it uses the `gdalwarp()` function (via the gdalcubes backend or an equivalent tool), which supports several interpolation methods:
+
+1. Nearest: Assigns the value of the nearest input pixel (fastest, preserves discrete classes).
+
+2. Bilinear: Performs linear interpolation from 4 nearest input pixels. Smooths intensity values.
+
+3. Cubic: Uses 16 surrounding pixels. Smoother, more complex but can introduce artifacts.
+
+By default, `sits` applies nearest-neighbor interpolation for categorical or discrete bands (e.g., land cover or polarization labels), and bilinear interpolation for continuous-valued bands (e.g., backscatter intensity). However, the exact interpolation method may vary depending on how the raster cube is created and the backend in use. Advanced users can customize reprojection parameters through sits_config() or environment variables that modify GDAL behavior.
+
+We illustrate the spatial harmonization feature of `sits_regularize()` in the following example, which uses the `"SENTINEL-1-RTC"` collection from the Microsoft Planetary Computer (MPC).
 
 ```{r}
 #| eval: false
@@ -199,7 +227,7 @@ plot(cube_s1_rtc, band = "VH", palette = "Greys", scale = 0.7)
 knitr::include_graphics("./images/cube_s1_rtc_tile_22LBL_vh.png") 
 ```
 
-After retrieving a non-regular ARD collection from the data available in MPC, we use `sits_regularize()` to produce a SAR data cube that matches MGRS tile "22LBL". For plotting the SAR image, we select a multidate plot for the "VH" band, where the first date will be displayed in red, the second in green and the third in blue, so as to show an RGB map where changes are visually enhanced.
+After retrieving a non-regular ARD collection from the Microsoft Planetary Computer (MPC), we use `sits_regularize()` to produce a SAR data cube aligned with MGRS tile "22LBL". To visualize the SAR data, we generate a multi-date plot of the "VH" polarization band. In this plot, the first date is displayed in red, the second in green, and the third in blue—producing an RGB composite that visually highlights changes over time.
 
 ```{r}
 #| eval: false
@@ -233,6 +261,6 @@ knitr::include_graphics("./images/dc_s1reg_three_dates.png")
 
 ## Summary 
 
-In this chapter, we learned how to produced regular EO cubes from non-regular subset of ARD collections. Regularization is a key operation when working with time series, since it allow the use of machine learning models on time series. In the next chapter, we will discuss how to merge sensors from different data sources and, when necessary, to combine these data sets with regularization operations. 
+In this chapter, we learned how to produce regular Earth observation (EO) data cubes from non-regular subsets of ARD collections. Regularization is a key operation when working with time series, as it enables the use of machine learning models on temporally aligned data. In the next chapter, we will discuss how to merge sensors from different data sources and, when necessary, how to combine these datasets with regularization operations.
 
 ## References{-}


### PR DESCRIPTION
This is a more substantial edit of the dc_regularize.qmd file, going beyond grammar corrections.

While reading the original text, I realized there were several aspects of sits_regularize() that I didn’t fully understand. I decided to expand on key points, especially regarding how spatial and temporal harmonization works. I rewrote parts of the text with the goal of making the explanations clearer for readers who, like myself, might be encountering these concepts for the first time.

Please review the technical content to ensure everything is accurate. I hope my understanding of sits_regularize() is correct and that the edits make the documentation more accessible to users with limited background in Earth observation.